### PR TITLE
修改vite的proxy配置

### DIFF
--- a/src/main/resources/static/.gitignore
+++ b/src/main/resources/static/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 .yarn
 .yarnrc.yml
+.vite.config-*.ts
 
 # Editor directories and files
 .vscode/*

--- a/src/main/resources/static/package.json
+++ b/src/main/resources/static/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev50": "vite --config vite.config-dev50.ts",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/src/main/resources/static/vite.config.ts
+++ b/src/main/resources/static/vite.config.ts
@@ -23,9 +23,8 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      // 代理后端api
-      // vite.config-*.ts已经配置在.gitignore里,不会被git管理
-      "^/api/.+": "http://10.0.11.50:8050",
+      // 该文件会放到git里，大家都会看到
+      "^/api/.+": "http://127.0.0.1:8050",
     },
   },
   build: {


### PR DESCRIPTION
增加个人配置文件vite.config.dev50.ts，不提交到github上，本地使用yarn dev50调试。vite.config.ts为公共配置